### PR TITLE
Create Headless service, and expose the POD_IP

### DIFF
--- a/k8s/manifests/services/codewar-headless.yml
+++ b/k8s/manifests/services/codewar-headless.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: codewar-headless
+spec:
+  clusterIP: None
+  ports:
+  - port: 80
+    targetPort: 4000
+  selector:
+    app: codewar-app

--- a/k8s/manifests/workloads/codewar.yaml
+++ b/k8s/manifests/workloads/codewar.yaml
@@ -10,7 +10,7 @@ spec:
     matchLabels:
       app: codewar-app
       tier: codewar
-  replicas: 2
+  replicas: 4
   strategy:
     rollingUpdate:
       maxSurge: 0
@@ -64,7 +64,7 @@ spec:
             - name: accept
               value: text/html
           initialDelaySeconds: 60
-          periodSeconds: 5
+          periodSeconds: 30
         readinessProbe:
           httpGet:
             path: /_health/readiness
@@ -73,4 +73,4 @@ spec:
             - name: accept
               value: text/html
           initialDelaySeconds: 60
-          periodSeconds: 5
+          periodSeconds: 30

--- a/k8s/manifests/workloads/codewar.yaml
+++ b/k8s/manifests/workloads/codewar.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         app: codewar-app
         tier: codewar
-    spec: 
+    spec:
       containers:
       - name: codewar-container
         image: 301618631622.dkr.ecr.ap-southeast-1.amazonaws.com/nimble-growth-39-aws-eks:nimble-growth-39
@@ -52,6 +52,10 @@ spec:
             value: admin
           - name: BASIC_AUTH_PASSWORD
             value: admin
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
         livenessProbe:
           httpGet:
             path: /_health/liveness


### PR DESCRIPTION
## What happened 👀

Support Elixir Cluster

## Insight 📝

1/ Create a Headless service
2/ Export the POD_IP 
3/ Increase the POD to 4 pods for the demo purpose
4/ Some minor tweak

## Proof Of Work 📹

![image](https://user-images.githubusercontent.com/11751745/180383047-ba95d9d6-e96d-4019-b8bc-848f25f894f1.png)

